### PR TITLE
fix the incorrect api key variable

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,4 @@
-const API_KEY = import.meta.env.VITE_API_KEY;
+const API_KEY = import.meta.env.VITE_TMDB_API_KEY;
 const BASE_URL = "https://api.themoviedb.org/3";
 
 export const getPopularMovies = async () => {


### PR DESCRIPTION
This pr fixes the incorrect api key variable for the users TMBD api key being imported from the .env file 

Closes #2

This prevents the app from loading and renders a blank page when running locally 

<img width="1679" height="923" alt="movie" src="https://github.com/user-attachments/assets/5c447fa9-15a1-469d-a0b4-9be5b46a3689" />

<img width="1585" height="933" alt="movie 2" src="https://github.com/user-attachments/assets/24572e01-1dff-4e64-b4ab-e1291a698476" />

