### PR TITLE
Fix: Roundness in Description close button

### DIFF
--- a/src/css/MovieDetails.css
+++ b/src/css/MovieDetails.css
@@ -34,7 +34,7 @@
   border-radius: 50%;
   width: 40px;
   height: 40px;
-  font-size: large;
+  font-size: larger;
   cursor: pointer;
   z-index: 10;
   display: flex;


### PR DESCRIPTION
This PR fixes an issue in which the roundness of close button in movie description page was not perfectly round. 
## Changes 
font-size of `close-btn` from `1.5rem` to `larger`

closes #28 