### PR TITLE
corrected the nav-bar dropdown in mobile-view and search icon color i…

### DIFF
--- a/src/css/Home.css
+++ b/src/css/Home.css
@@ -17,7 +17,6 @@
   box-shadow: var(--shadow);
   overflow: visible;
   position: relative;
-  z-index: 100;
   transition: all 0.3s ease;
 }
 
@@ -139,7 +138,7 @@
 }
 
 .search-form::before {
-  content: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3ccircle cx='11' cy='11' r='8'/%3e%3cpath d='m21 21-4.35-4.35'/%3e%3c/svg%3e");
+  content: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3ccircle cx='11' cy='11' r='8'/%3e%3cpath d='m21 21-4.35-4.35'/%3e%3c/svg%3e");
   position: absolute;
   left: 1.5rem;
   top: 50%;

--- a/src/css/NavBar.css
+++ b/src/css/NavBar.css
@@ -154,6 +154,7 @@
   z-index: 60;
 }
 
+
 .hamburger-line {
   width: 100%;
   height: 3px;


### PR DESCRIPTION
…n the searchinput form

# 🔀 Pull Request

## 📝 Summary
Improved the mobile navigation experience by fixing the overlapping dropdown issue with search input form. Also updated the search icon color in the home page search input for better theme consistency.

## 🔧 Type of Change
- [x] 🐛 Bug fix
- [x] ✨ New feature


## 🔄 Changes Made

Fixed navbar dropdown z-index and visual overlap issues.

Updated search icon color in search input form for better contrast.


## 🧪 How to Test
Steps to verify this PR locally:

Run the app and resize the screen below 768px.

Click the hamburger icon to verify it changes into opens/closes the menu smoothly.

Ensure the dropdown overlays the page correctly without overlapping content.

Check the home page search input to confirm the new search icon color is applied.

# Screenshots
- before
<img width="485" height="591" alt="Screenshot From 2025-10-26 17-24-59" src="https://github.com/user-attachments/assets/a2672cd7-d154-45d2-9e8d-38ba50527545" />

- after
<img width="468" height="728" alt="Screenshot From 2025-10-26 17-48-22" src="https://github.com/user-attachments/assets/59395334-2336-4743-874f-79012c0c0119" />

